### PR TITLE
Config file option added.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,6 +42,25 @@ wghttp \
   --exit-mode=remote
 ```
 
+or:
+
+```bash
+wghttp --config wghttp.ini [further options]
+```
+
+with a config file `wghttp.ini` like this:
+
+```ini
+[Application Options]
+client-ip=10.200.100.8
+dns=10.200.100.1
+private-key=oK56DE9Ue9zK76rAc8pBl6opph+1v36lm7cXXsQKrQM=
+peer-key=GtL7fZc/bLnqZldpVofMCD6hDjrK28SsdLxevJ+qtKU=
+peer-endpoint=demo.wireguard.com:51820
+preshared-key=/UwcSPg38hW/D9Y3tcS1FOV0K1wuURMbS0sesJEP5ak=
+exit-mode=remote
+```
+
 ## Dynamic DNS
 
 When your server IP is not persistent, you can set a domain with

--- a/main.go
+++ b/main.go
@@ -29,6 +29,11 @@ func main() {
 	parser := flags.NewParser(&opts, flags.Default)
 	parser.LongDescription = fmt.Sprintf("wghttp %s\n\n", version())
 	parser.LongDescription += strings.Trim(strings.TrimPrefix(readme, "# wghttp"), "\n")
+	// see https://github.com/jessevdk/go-flags/issues/106
+	opts.Config = func(filename string) error {
+		ini := flags.NewIniParser(parser)
+		return ini.ParseFile(filename)
+	}
 	if _, err := parser.Parse(); err != nil {
 		code := 1
 		fe := &flags.Error{}

--- a/option.go
+++ b/option.go
@@ -58,11 +58,12 @@ func (o *timeT) UnmarshalFlag(value string) error {
 }
 
 type options struct {
-	ClientIPs  []ipT  `long:"client-ip" env:"CLIENT_IP" env-delim:"," required:"true" description:"[Interface].Address\tfor WireGuard client (can be set multiple times)"`
-	ClientPort int    `long:"client-port" env:"CLIENT_PORT" description:"[Interface].ListenPort\tfor WireGuard client (optional)"`
-	PrivateKey keyT   `long:"private-key" env:"PRIVATE_KEY" required:"true" description:"[Interface].PrivateKey\tfor WireGuard client (format: base64)"`
-	DNS        string `long:"dns" env:"DNS" description:"[Interface].DNS\tfor WireGuard network (format: protocol://ip:port)\nProtocol includes udp(default), tcp, tls(DNS over TLS) and https(DNS over HTTPS)"`
-	MTU        int    `long:"mtu" env:"MTU" default:"1280" description:"[Interface].MTU\tfor WireGuard network"`
+	Config     func(filename string) error `short:"c" long:"config" description:"config file with [Application Options] and option values" no-ini:"true"`
+	ClientIPs  []ipT                       `long:"client-ip" env:"CLIENT_IP" env-delim:"," required:"true" description:"[Interface].Address\tfor WireGuard client (can be set multiple times)"`
+	ClientPort int                         `long:"client-port" env:"CLIENT_PORT" description:"[Interface].ListenPort\tfor WireGuard client (optional)"`
+	PrivateKey keyT                        `long:"private-key" env:"PRIVATE_KEY" required:"true" description:"[Interface].PrivateKey\tfor WireGuard client (format: base64)"`
+	DNS        string                      `long:"dns" env:"DNS" description:"[Interface].DNS\tfor WireGuard network (format: protocol://ip:port)\nProtocol includes udp(default), tcp, tls(DNS over TLS) and https(DNS over HTTPS)"`
+	MTU        int                         `long:"mtu" env:"MTU" default:"1280" description:"[Interface].MTU\tfor WireGuard network"`
 
 	PeerEndpoint      hostPortT `long:"peer-endpoint" env:"PEER_ENDPOINT" required:"true" description:"[Peer].Endpoint\tfor WireGuard server (format: host:port)"`
 	PeerKey           keyT      `long:"peer-key" env:"PEER_KEY" required:"true" description:"[Peer].PublicKey\tfor WireGuard server (format: base64)"`


### PR DESCRIPTION
Addresses #10 by allowing config files in own format (not 1:1 wireguard-go), as supported by go-flags.